### PR TITLE
Fix restart command and change behaviour slightly

### DIFF
--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -1933,11 +1933,8 @@ class MusicBot(discord.Client):
             percentage = 0.0
             if player.current_entry.duration > 0:
                 percentage = player.progress / player.current_entry.duration
-            """
-            This for loop adds  empty or full squares to prog_bar_str (it could look like
-            ■■■■■■■■■■□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□
-            if for example the song has already played 25% of the songs duration
-            """
+
+            # create the actual bar
             progress_bar_length = 30
             for i in range(progress_bar_length):
                 if (percentage < 1 / progress_bar_length * i):

--- a/run.py
+++ b/run.py
@@ -321,9 +321,6 @@ def pyexec(pycom, *args, pycom2=None):
     pycom2 = pycom2 or pycom
     os.execlp(pycom, pycom2, *args)
 
-def restart(*args):
-    pyexec(sys.executable, *args, *sys.argv, pycom2='python')
-
 
 def main():
     # TODO: *actual* argparsing
@@ -394,7 +391,8 @@ def main():
                     break
 
                 elif e.__class__.__name__ == "RestartSignal":
-                    restart()
+                    loops = 0
+                    pass
             else:
                 log.exception("Error starting bot")
 


### PR DESCRIPTION
Restarting via the command will not restart the entire script, and will instead refresh the config and bot instances. This means that a hard restart will be needed when doing something like updating the bot or dependencies, rather than using the restart command. Closes #1503, fixes #603, fixes #901.

Please make sure these boxes are checked (put an 'x' inside them) **before** creating the pull request.

- [ ] I have tested my changes against the `review` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [ ] I have tested my changes on Python 3.5/3.6

----

### Description



### Related issues (if applicable)

